### PR TITLE
Fix invalid resume markup and missing avatar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ sass:
   style: compressed
 
 # Resume settings
-resume_avatar:                  "true"
+resume_avatar:                  "false"
 resume_name:                    "David Gitman"
 resume_title:                   "Technology Leader | Ecommerce, Cloud Infrastructure & AI Automation | Headless Commerce, DevOps & Growth Systems | Startup & Venture Ecosystems"
 

--- a/_layouts/resume.html
+++ b/_layouts/resume.html
@@ -60,7 +60,7 @@
         <div class="resume-item" itemscope itemprop="worksFor" itemtype="http://schema.org/Organization">
           <h3 class="resume-item-title" itemprop="name">{{ job.company }}</h3>
           <h4 class="resume-item-details" itemprop="description">{{ job.position }} &bull; {{ job.duration }}</h4>
-          <p class="resume-item-copy">{{ job.summary }}</p>
+          <div class="resume-item-copy">{{ job.summary }}</div>
         </div><!-- end of resume-item -->
         {% endfor %}
 
@@ -81,15 +81,19 @@
           <h3 class="resume-item-title" itemprop="name">{{ education.uni }}</h3>
           <h4 class="resume-item-details group" itemprop="description">{{ education.degree }} &bull; {{ education.year }}</h4>
           <h5 class="resume-item-details award-title" itemprop="description">{{ education.award }}</h5>
-          <p class="resume-item-copy" itemprop="description">
+          <div class="resume-item-copy" itemprop="description">
+            {% if education.awards %}
             <ul class="resume-item-list">
               {% for award in education.awards %}
               <li>{{ award.award }}</li>
               {% endfor %}
             </ul>
+            {% endif %}
 
-
-          <p class="resume-item-copy">{{ education.summary }}</p>
+            {% if education.summary %}
+            <div>{{ education.summary }}</div>
+            {% endif %}
+          </div>
         </div>
         {% endfor %}
       </section>
@@ -109,7 +113,7 @@
           <meta itemprop="creator" content="{{ site.resume_name }}" itemtype="http://schema.org/Person" />
           <h3 class="resume-item-title" itemprop="name">{% if project.url %}<a href="{{ project.url }}" itemprop="url">{{ project.project }}</a>{% else %}{{ project.project }}{% endif %}</h3>
           <h4 class="resume-item-details" itemprop="description">{{ project.role }}  &bull; {{ project.duration }}</h4>
-          <p class="resume-item-copy">{{ project.description }}</p>
+          <div class="resume-item-copy">{{ project.description }}</div>
         </div>
         {% endfor %}
 
@@ -127,7 +131,7 @@
         {% for skill in site.data.skills %}
         <div class="resume-item">
           <h4 class="resume-item-details">{{ skill.skill }}</h4>
-          <p class="resume-item-copy">{{ skill.description }}</p>
+          <div class="resume-item-copy">{{ skill.description }}</div>
         </div>
         {% endfor %}
 
@@ -147,7 +151,7 @@
         <div class="resume-item">
           <h3 class="resume-item-title" itemprop="award">{{ recognition.award }}</h3>
           <h4 class="resume-item-details">{{ recognition.organization }} &bull; {{ recognition.year }}</h4>
-          <p class="resume-item-copy">{{ recognition.summary }}</p>
+          <div class="resume-item-copy">{{ recognition.summary }}</div>
         </div>
         {% endfor %}
 
@@ -167,7 +171,7 @@
         <div class="resume-item" itemscope itemprop="memberOf" itemtype="http://schema.org/Organization">
           <h3 class="resume-item-title" itemprop="name">{% if association.url %}<a href="{{ association.url }}">{{ association.organization }}</a>{% else %}{{ association.organization }}{% endif %}</h3>
           <h4 class="resume-item-details" itemprop="description">{{ association.role }} &bull; {{ association.year }}</h4>
-          <p class="resume-item-copy">{{ association.summary }}</p>
+          <div class="resume-item-copy">{{ association.summary }}</div>
         </div>
         {% endfor %}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Disable the avatar in config because the referenced `images/avatar.jpg` asset is not present.
- Render resume summary snippets in block containers so existing HTML paragraphs are not nested inside `<p>` tags.
- Clean up the education awards/summary markup so the list is not emitted inside an unclosed paragraph.

## Testing
- `python3` static validation: parsed `_config.yml`, confirmed the avatar is disabled, confirmed the Twitter URL still parses correctly, and confirmed `_layouts/resume.html` no longer contains `p.resume-item-copy` wrappers.

## Notes
- Native Jekyll build was not available in this environment because Ruby/Bundler are not installed, and Docker is also unavailable.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://because-ventures.slack.com/archives/D0B8WME3LRJ/p1780783477579959?thread_ts=1780783477.579959&cid=D0B8WME3LRJ)

<div><a href="https://cursor.com/agents/bc-e90d9761-30f9-56a2-b9f7-f26896b235c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e90d9761-30f9-56a2-b9f7-f26896b235c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

